### PR TITLE
Implement validation_step to call training_step

### DIFF
--- a/cosmos_predict2/_src/predict2/models/text2world_model_rectified_flow.py
+++ b/cosmos_predict2/_src/predict2/models/text2world_model_rectified_flow.py
@@ -591,7 +591,7 @@ class Text2WorldModelRectifiedFlow(ImaginaireModel):
     def validation_step(
         self, data: dict[str, torch.Tensor], iteration: int
     ) -> tuple[dict[str, torch.Tensor], torch.Tensor]:
-        pass
+        return self.training_step(data, iteration)
 
     @torch.no_grad()
     def forward(self, xt, t, condition: Text2WorldCondition):


### PR DESCRIPTION
This fix allows the model inhering from it (e.g. `Video2WorldModelRectifiedFlow`) to perform the validation step. Inspired by [Predict2](https://github.com/nvidia-cosmos/cosmos-predict2/blob/661da4774b0ca41d082a0ecbeb47550bcf07e03f/cosmos_predict2/models/video2world_model.py#L498)
