### PR TITLE
add auto regressive inference mode for predict2.5 auto multiview

### DIFF
--- a/cosmos_predict2/_src/predict2_multiview/scripts/inference.py
+++ b/cosmos_predict2/_src/predict2_multiview/scripts/inference.py
@@ -31,6 +31,7 @@ import argparse
 import os
 
 import torch as th
+from einops import rearrange
 from megatron.core import parallel_state
 
 from cosmos_predict2._src.imaginaire.lazy_config import instantiate
@@ -163,6 +164,68 @@ class Vid2VidInference:
         )
         # (bsz = 1, c = 3, t = n_camera * t, h, w)
         video = ((self.model.decode(sample) + 1.0) / 2.0).clamp(0, 1)
+
+        # Arrange video according to stack_mode
+        video = arrange_video_visualization(video, data_batch, method=stack_mode)
+        return video
+
+    def generate_from_batch_autoregressive(
+        self,
+        data_batch,
+        num_chunks=2,
+        chunk_overlap=2,
+        guidance: int = 7,
+        seed: int = 1,
+        num_steps: int = 35,
+        stack_mode: str = "time",
+        use_negative_prompt: bool = True,
+    ):
+        """Generate video tensor from batch, with autoregressive mode enabled
+        num_chunks: total number of single generation
+        chunk_overlap: overlap the
+        """
+        data_batch = to_model_input(data_batch, self.model)
+        if self.model.config.text_encoder_config is not None and self.model.config.text_encoder_config.compute_online:
+            self.model.inplace_compute_text_embeddings_online(data_batch)
+
+        n_views = len(data_batch["camera_keys_selection"][0])
+        num_video_frames_per_view = data_batch["num_video_frames_per_view"][0]
+
+        generated_chunks = []
+
+        for i in range(num_chunks):
+            log.info(f"start generate chunk {i + 1} / {num_chunks}")
+            _, x0, _ = self.model.get_data_and_condition(data_batch)
+            sample = self.model.generate_samples_from_batch(
+                data_batch,
+                guidance=guidance,
+                # make sure no mismatch and also works for cp
+                state_shape=x0.shape[1:],
+                n_sample=x0.shape[0],
+                seed=seed,  # Fixed seed for reproducibility
+                num_steps=num_steps,
+                is_negative_prompt=use_negative_prompt,
+            )
+            # (bsz = 1, c = 3, t = n_camera * t, h, w)
+            decoded = self.model.decode(sample)
+            chunk_video = ((decoded + 1.0) / 2.0).clamp(0, 1)[0]
+            chunk_video = rearrange(chunk_video, "C (V T) H W -> V C T H W", V=n_views)
+            if i == 0:
+                generated_chunks.append(chunk_video)
+            else:
+                generated_chunks.append(chunk_video[:, :, chunk_overlap:])
+            data_batch["num_conditional_frames"] = chunk_overlap
+            data_batch["video"].zero_()
+            for v in range(n_views):
+                start_idx = num_video_frames_per_view * v
+                overlaps = (
+                    chunk_video[v, :, num_video_frames_per_view - chunk_overlap : num_video_frames_per_view] * 255
+                )
+                overlaps = overlaps.to(th.uint8).clamp(0, 255)
+                data_batch["video"][:, :, start_idx : start_idx + chunk_overlap] = overlaps
+
+        video = th.cat(generated_chunks, dim=2)
+        video = rearrange(video, "V C T H W -> C (V T) H W", V=n_views).unsqueeze(0)
 
         # Arrange video according to stack_mode
         video = arrange_video_visualization(video, data_batch, method=stack_mode)

--- a/cosmos_predict2/multiview.py
+++ b/cosmos_predict2/multiview.py
@@ -202,13 +202,24 @@ class MultiviewInference:
 
         batch = next(iter(dataloader))
         batch[NUM_CONDITIONAL_FRAMES_KEY] = sample.num_input_frames
-        video = self.pipe.generate_from_batch(
-            batch,
-            guidance=sample.guidance,
-            seed=sample.seed,
-            stack_mode=sample.stack_mode,
-            num_steps=sample.num_steps,
-        )
+        if sample.enable_autoregressive:
+            video = self.pipe.generate_from_batch_autoregressive(
+                batch,
+                sample.num_chunks,
+                sample.chunk_overlap,
+                guidance=sample.guidance,
+                seed=sample.seed,
+                stack_mode=sample.stack_mode,
+                num_steps=sample.num_steps,
+            )
+        else:
+            video = self.pipe.generate_from_batch(
+                batch,
+                guidance=sample.guidance,
+                seed=sample.seed,
+                stack_mode=sample.stack_mode,
+                num_steps=sample.num_steps,
+            )
         if self.rank0:
             video = video[0]
 
@@ -250,13 +261,24 @@ class MultiviewInference:
         # pyrefly: ignore  # no-matching-overload
         for batch in iter(dataloader):
             batch[NUM_CONDITIONAL_FRAMES_KEY] = sample.num_input_frames
-            video = self.pipe.generate_from_batch(
-                batch,
-                guidance=sample.guidance,
-                seed=sample.seed,
-                stack_mode=sample.stack_mode,
-                num_steps=sample.num_steps,
-            )
+            if sample.enable_autoregressive:
+                video = self.pipe.generate_from_batch_autoregressive(
+                    batch,
+                    sample.num_chunks,
+                    sample.chunk_overlap,
+                    guidance=sample.guidance,
+                    seed=sample.seed,
+                    stack_mode=sample.stack_mode,
+                    num_steps=sample.num_steps,
+                )
+            else:
+                video = self.pipe.generate_from_batch(
+                    batch,
+                    guidance=sample.guidance,
+                    seed=sample.seed,
+                    stack_mode=sample.stack_mode,
+                    num_steps=sample.num_steps,
+                )
             save_path = output_path / f"{batch['__key__'][0]}"
             if self.rank0:
                 video = video[0]

--- a/cosmos_predict2/multiview_config.py
+++ b/cosmos_predict2/multiview_config.py
@@ -81,6 +81,20 @@ class MultiviewInferenceArguments(CommonInferenceArguments):
     stack_mode: Stacuserde = "time"
     """Stacking mode for frames."""
 
+    # Autoregressive inference mode
+    enable_autoregressive: bool = False
+    """Enable autoregressive mode to generate videos longer than the model's native temporal capacity."""
+    num_chunks: int = pydantic.Field(
+        default=2,
+        ge=1,
+        description="Number of chunks to process auto-regressively",
+    )
+    """Number of frames the model generates per view in a single forward pass (chunk size, typically 29 or 61)."""
+    chunk_overlap: int = pydantic.Field(
+        default=1, description="Number of overlapping frames between consecutive chunks"
+    )
+    """Number of overlapping frames between consecutive chunks for temporal consistency."""
+
     fps: pydantic.PositiveInt = 30
     """Frames per second for output video."""
     num_steps: pydantic.PositiveInt = 1 if SMOKE else 35


### PR DESCRIPTION
This is a PR to enable the autoregressive inference mode for auto/multiview. If it is enabled, it will inference multi-times to generate longer video (>29 frames). For each inference, it will condition on last `chunk_overlap` frames and generate next chunk. I test with `assets/multiview/urban_freeway.json`