### PR TITLE
Fix timestamp frame selection for torchvision/pyav backend

### DIFF
--- a/cosmos_predict2/_src/predict2/action/datasets/gr00t_dreams/utils/video.py
+++ b/cosmos_predict2/_src/predict2/action/datasets/gr00t_dreams/utils/video.py
@@ -110,12 +110,16 @@ def get_frames_by_timestamps(
         # load all frames from first to last requested timestamp
         loaded_frames = []
         loaded_ts = []
+        # Read one extra frame past last_ts to allow nearest-neighbor on the right.
+        read_past_last = False
         for frame in reader:
             current_ts = frame["pts"]
             loaded_frames.append(frame["data"])
             loaded_ts.append(current_ts)
-            if current_ts >= last_ts:
+            if read_past_last:
                 break
+            if current_ts >= last_ts:
+                read_past_last = True
         reader.container.close()
         reader = None
 


### PR DESCRIPTION
The torchvision/pyav path in get_frames_by_timestamps now reads frames until the final requested timestamp and then selects the closest loaded frame for each requested timestamp. This prevents early exit when the number of loaded frames equals the number of requested timestamps and avoids returning the first contiguous frames after seek instead of the requested ones. It also raises a clear error if no frames were loaded.

This fix is helpful for intentional downsampling. If a user has 10Hz video and wants to sample 5 frames at 5Hz, the current torchvision/pyav backend returns the wrong frames.

## Example (10Hz video)
At 10Hz, each frame is 0.1s apart: frame 0 = 0.0s, frame 1 = 0.1s, frame 2 = 0.2s, etc.
Requested frames: 0, 2, 4, 6, 8 (timestamps 0.0s, 0.2s, 0.4s, 0.6s, 0.8s)

Before: the loop stops after loading 5 frames and returns the first 5 loaded frames.
Returned frames: 0, 1, 2, 3, 4
Returned timestamps: 0.0s, 0.1s, 0.2s, 0.3s, 0.4s

After: the loop reads until 0.8s and maps each requested timestamp to the closest loaded frame.
Returned frames: 0, 2, 4, 6, 8
Returned timestamps: 0.0s, 0.2s, 0.4s, 0.6s, 0.8s
