### PR TITLE
Fix mutable default arguments and remove duplicate line in VLM models

### DIFF
--- a/cosmos_predict2/_src/predict2/text_encoders/reason1.py
+++ b/cosmos_predict2/_src/predict2/text_encoders/reason1.py
@@ -231,10 +231,12 @@ class QwenVLBaseModel(QwenModel):
     MODIFICATIONS: adding the hidden states to the output.
     """
 
-    def forward(self, tokens, data_batch={}, start_pos: int = 0) -> torch.Tensor:
+    def forward(self, tokens, data_batch=None, start_pos: int = 0) -> torch.Tensor:
         """
         The training step of the model, including the loss computation.
         """
+        if data_batch is None:
+            data_batch = {}
         assert "pixel_values" not in data_batch, "pixel_values should not be in data_batch, use images instead"
         pixel_values = data_batch.get("images", None)
         image_grid_thw = data_batch.get("image_grid_thw", None)

--- a/cosmos_predict2/_src/reason1/models/vlm_base.py
+++ b/cosmos_predict2/_src/reason1/models/vlm_base.py
@@ -414,7 +414,7 @@ class VLMBaseModel(torch.nn.Module):
     def build_model(self, model_config):
         raise NotImplementedError
 
-    def forward(self, tokens, data_batch={}, start_pos: int = 0) -> torch.Tensor:
+    def forward(self, tokens, data_batch=None, start_pos: int = 0) -> torch.Tensor:
         """
         The forward pass of the model.
         Returns:

--- a/cosmos_predict2/_src/reason1/models/vlm_qwen.py
+++ b/cosmos_predict2/_src/reason1/models/vlm_qwen.py
@@ -370,10 +370,12 @@ class QwenModel(VLMBaseModel):
             logits = DTensor.from_local(logits, device_mesh=self.cp_mesh, placements=[Shard(1)]).full_tensor()
         return logits
 
-    def forward(self, tokens, data_batch={}, start_pos: int = 0) -> torch.Tensor:
+    def forward(self, tokens, data_batch=None, start_pos: int = 0) -> torch.Tensor:
         """
         The training step of the model, including the loss computation.
         """
+        if data_batch is None:
+            data_batch = {}
         assert "pixel_values" not in data_batch, "pixel_values should not be in data_batch, use images instead"
         pixel_values = data_batch.get("images", None)
         image_grid_thw = data_batch.get("image_grid_thw", None)

--- a/cosmos_predict2/_src/reason1/models/vlm_qwen_omni.py
+++ b/cosmos_predict2/_src/reason1/models/vlm_qwen_omni.py
@@ -268,17 +268,17 @@ class QwenVLBaseModel(QwenModel):
     MODIFICATIONS: adding the hidden states to the output.
     """
 
-    def forward(self, tokens, data_batch={}, start_pos: int = 0) -> torch.Tensor:
+    def forward(self, tokens, data_batch=None, start_pos: int = 0) -> torch.Tensor:
         """
         The training step of the model, including the loss computation.
         """
+        if data_batch is None:
+            data_batch = {}
         assert "pixel_values" not in data_batch, "pixel_values should not be in data_batch, use images instead"
         pixel_values = data_batch.get("images", None)
         image_grid_thw = data_batch.get("image_grid_thw", None)
         pixel_values_videos = data_batch.get("videos", None)
         video_grid_thw = data_batch.get("video_grid_thw", None)
-        attention_mask = data_batch.get("padding_mask", None)
-
         attention_mask = data_batch.get("padding_mask", None)
 
         if image_grid_thw is not None:


### PR DESCRIPTION
## Summary

- Replaced mutable dict default `data_batch={}` with `data_batch=None` (+ guard) in `forward()` across 4 VLM model files. Mutable defaults in Python are shared across all calls to the function, which can lead to unexpected shared state if the dict is ever modified in-place.
- Removed duplicate `attention_mask = data_batch.get("padding_mask", None)` assignment in `vlm_qwen_omni.py`.

**Files changed:**
- `cosmos_predict2/_src/reason1/models/vlm_base.py`
- `cosmos_predict2/_src/reason1/models/vlm_qwen.py`
- `cosmos_predict2/_src/reason1/models/vlm_qwen_omni.py`
- `cosmos_predict2/_src/predict2/text_encoders/reason1.py`