### PR TITLE
Fix: convert chunk_overlap from pixel to latent frames in autoregressive generation

### DIFF
--- a/cosmos_predict2/_src/predict2/inference/video2world.py
+++ b/cosmos_predict2/_src/predict2/inference/video2world.py
@@ -700,8 +700,8 @@ class Video2WorldInference:
             prompt: The text prompt describing the desired video content/style.
             input_path: Path to the input image or video file or a torch.Tensor.
             num_output_frames: Total number of frames to generate in the final output.
-            chunk_size: Number of frames per chunk (model's native capacity).
-            chunk_overlap: Number of overlapping frames between chunks.
+            chunk_size: Number of pixel frames per chunk (model's native capacity).
+            chunk_overlap: Number of overlapping pixel frames between consecutive chunks.
             guidance: Classifier-free guidance scale.
             num_latent_conditional_frames: Number of latent conditional frames.
             resolution: Target video resolution in "H,W" format.
@@ -850,11 +850,11 @@ class Video2WorldInference:
                 ).to(chunk_input.dtype)
                 chunk_input = torch.cat([chunk_input, padding], dim=2)
 
-            # Determine num_conditional_frames for this chunk
+            # Determine num_latent_conditional for the model (latent space) for this chunk.
             if chunk_idx == 0:
-                chunk_num_conditional = num_latent_conditional_frames
+                chunk_latent_conditional = num_latent_conditional_frames
             else:
-                chunk_num_conditional = chunk_overlap
+                chunk_latent_conditional = self.model.tokenizer.get_latent_num_frames(chunk_overlap)
 
             # Generate chunk
             chunk_video = self.generate_vid2world(
@@ -862,7 +862,7 @@ class Video2WorldInference:
                 input_path=chunk_input,
                 guidance=guidance,
                 num_video_frames=model_required_frames,
-                num_latent_conditional_frames=chunk_num_conditional,
+                num_latent_conditional_frames=chunk_latent_conditional,
                 resolution=resolution,
                 seed=seed + chunk_idx,
                 negative_prompt=negative_prompt,
@@ -878,19 +878,15 @@ class Video2WorldInference:
             if chunk_idx == 0:
                 generated_chunks.append(chunk_video)
             else:
-                # Remove overlap frames from the beginning
                 generated_chunks.append(chunk_video[:, :, chunk_overlap:, :, :])
 
             # Update input for next iteration using generated frames
             if chunk_idx < num_chunks - 1:
                 # Convert generated chunk from [-1, 1] to [0, 255] uint8 range
                 chunk_video_uint8 = ((chunk_video / 2.0 + 0.5).clamp(0.0, 1.0) * 255.0).to(torch.uint8)
-                # Update the input video with generated frames for conditioning next chunk
-                update_start = start_frame + chunk_num_conditional
+                update_start = start_frame + chunk_overlap
                 update_end = end_frame
-                current_input_video[:, :, update_start:update_end, :, :] = chunk_video_uint8[
-                    :, :, chunk_num_conditional:, :, :
-                ]
+                current_input_video[:, :, update_start:update_end, :, :] = chunk_video_uint8[:, :, chunk_overlap:, :, :]
 
         # Concatenate all chunks along time dimension
         final_video = torch.cat(generated_chunks, dim=2)


### PR DESCRIPTION
## Summary

`generate_autoregressive_from_batch` in `video2world.py` passes `chunk_overlap` directly as `num_latent_conditional_frames` to the model. However, `chunk_overlap` is in **pixel frames** while `num_latent_conditional_frames` expects **latent frames**. With the tokenizer's 4:1 causal temporal compression, this causes a mismatch between what the model conditions on and what pixel-space slicing assumes, producing artifacts at chunk boundaries during autoregressive video generation.

For example, with `chunk_overlap=5`:
- **Before (bug):** model conditions on 5 latent frames = 17 pixel frames, but only 5 pixel frames are skipped in concatenation
- **After (fix):** model conditions on `get_latent_num_frames(5)` = 2 latent frames = 5 pixel frames, matching the 5 pixel frames skipped

The fix converts `chunk_overlap` to latent frames only when passing to the model, and uses the original pixel value for all pixel-space operations. This matches the approach already used in [cosmos-transfer2.5](https://github.com/nvidia-cosmos/cosmos-transfer2.5/blob/main/cosmos_transfer2/_src/transfer2/inference/inference_pipeline.py#L624) for the equivalent chunked generation logic.

## Why it went unnoticed

The default `chunk_overlap=1`, and `get_latent_num_frames(1) = 1` — the conversion is identity for this value. The bug only manifests when `chunk_overlap >= 2`.

## Changes

- Convert `chunk_overlap` (pixel) to latent frames via `tokenizer.get_latent_num_frames()` before passing to the model
- Keep all pixel-space operations (`effective_chunk_size`, chunk concatenation, input buffer update) using the original `chunk_overlap` value
- Update docstring to clarify that `chunk_overlap` and `chunk_size` are in pixel frames

## Test plan

- [ ] Verify `chunk_overlap=1` (default) produces identical output to the unfixed code (no behavior change for the common case)
- [ ] Verify `chunk_overlap=5` produces smooth transitions at chunk boundaries (no artifacts)
- [ ] Verify output frame count is correct for various `num_output_frames` / `chunk_overlap` combinations