### PR TITLE
fix: derive checkpoint_format from resolved local path (LoRA base weights silently not loaded)

### DIFF
--- a/cosmos_predict2/_src/predict2/utils/model_loader.py
+++ b/cosmos_predict2/_src/predict2/utils/model_loader.py
@@ -217,6 +217,12 @@ def load_model_state_dict_from_checkpoint(
 
     load_from_local = True
     local_s3_ckpt_fp = get_checkpoint_path(cur_key_ckpt_full_path)
+    # The checkpoint DB can resolve a DCP-style URI to a consolidated .pt file.
+    # The LoRA key-mapping branch below is gated on checkpoint_format == "pt",
+    # so derive the format from the resolved file, otherwise a PEFT-wrapped model
+    # silently loads zero parameters and trains from a random base.
+    if str(local_s3_ckpt_fp).endswith(".pt"):
+        checkpoint_format = "pt"
 
     if SMOKE:
         return model


### PR DESCRIPTION
## What

`checkpoint_format` is computed from the configured `checkpoint.load_path` string, but `get_checkpoint_path()` may resolve a DCP-style URI to a consolidated `.pt` file. The LoRA key-mapping branch is gated on `checkpoint_format == "pt"`, so PEFT-wrapped models (`use_lora=True`) load **zero** parameters under the non-strict load and train from random init — with no error raised. This derives the format from the resolved file instead.

Fixes #160. Also matches the long-standing symptom reported in `nvidia-cosmos/cosmos-predict2#176` (LoRA model produces identical/degenerate results vs. base; checkpoint-loading warnings).

## Change

One conditional in `cosmos_predict2/_src/predict2/utils/model_loader.py`, immediately after the `get_checkpoint_path(...)` resolution:

```python
    if str(local_s3_ckpt_fp).endswith(".pt"):
        checkpoint_format = "pt"
```

## Verification

Cosmos-Predict2.5-2B LoRA post-training (rank 32, single H100), per the issue's reproduction:

| | Before | After |
|---|---|---|
| Startup log | `_IncompatibleKeys(missing_keys=[<all base params>])`, no LoRA-mapping line | `Mapped 689 LoRA keys from checkpoint to model` |
| First-iter loss | ~3.04 (random base) | ~0.03 (loaded base) |
| Generation | noise | coherent video |

No behavior change for runs whose `load_path` already ends in `.pt` (the condition only promotes `dcp`→`pt` when the resolved file is a `.pt`).
