### PR TITLE
Replace deprecated transforms.v2.ToTensor() with transforms.v2.ToImage() + transforms.v2.ToDtype(scale=True)

### DIFF
--- a/cosmos_predict2/robot_multiview.py
+++ b/cosmos_predict2/robot_multiview.py
@@ -164,7 +164,8 @@ class TextImageCameraDataset(torch.utils.data.Dataset):
                 # pyrefly: ignore  # implicit-import
                 transforms.v2.Resize(size=(self.height, self.width), antialias=True),
                 # pyrefly: ignore  # implicit-import
-                transforms.v2.ToTensor(),
+                transforms.v2.ToImage(),
+                transforms.v2.ToDtype(torch.float32, scale=True),
                 # pyrefly: ignore  # implicit-import
                 transforms.v2.Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
             ]


### PR DESCRIPTION
Fix #166

## Summary

Replaces the deprecated `v2.ToTensor()` in `cosmos_predict2/robot_multiview.py` with the officially recommended `v2.ToImage()` + `v2.ToDtype(torch.float32, scale=True)`.

`v2.ToTensor()` has emitted a `UserWarning` on construction since torchvision 0.15 (first release of the v2 namespace); the warning text explicitly recommends this exact replacement:

> The transform `ToTensor()` is deprecated and will be removed in a future release. Instead, please use `v2.Compose([v2.ToImage(), v2.ToDtype(torch.float32, scale=True)])`. Output is equivalent up to float precision.

## Changes

- `cosmos_predict2/robot_multiview.py`: `v2.ToTensor()` → `v2.ToImage()` + `v2.ToDtype(torch.float32, scale=True)` inside the existing `v2.Compose`.

## Validation

Verified with torchvision 0.26.0 (CPU): the replacement pipeline constructs cleanly under `-W error::UserWarning`, and its output is identical to the old pipeline up to float precision (max abs diff ≈ 1e-7, single last-bit rounding on uint8→float32 scaling).